### PR TITLE
Update mysql-5.7.yml

### DIFF
--- a/MySQL/mysql-5.7/mysql-5.7.yml
+++ b/MySQL/mysql-5.7/mysql-5.7.yml
@@ -5,7 +5,7 @@ metadata:
   name: mysql-secrets
 type: Opaque
 data:
-  ROOT_PASSWORD: c3VwZXItc2VjcmV0LXBhc3N3b3JkCg==
+  ROOT_PASSWORD: c3VwZXItc2VjcmV0LXBhc3N3b3Jk
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
Fixed Improperly encoded base64 value for secret key MYSQL_ROOT_PASSWORD.